### PR TITLE
fix:修复登录后 无法匹配404页

### DIFF
--- a/src/components/ContentMain/index.js
+++ b/src/components/ContentMain/index.js
@@ -12,11 +12,12 @@ class ContentMain extends Component{
                     {
                         routes.map(item=>{
                             return (
-                                item.path?<PrivateRoute path={item.path} exact component={item.component}/>:<Route component={NoMatch}/>
+                                <PrivateRoute path={item.path} exact component={item.component}/>
+                                // item.path?<PrivateRoute path={item.path} exact component={item.component}/>:<Route component={NoMatch}/>
                             )
                         })
                     }
-                    
+                    <Route component={NoMatch}/>
                 </Switch>
             </div>
         )


### PR DESCRIPTION
登录后未匹配路由不显示404页面
修改 ContentMain/index.js 未匹配路由显示NoMatch